### PR TITLE
Update wlan_hdd_hostapd.c

### DIFF
--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_hostapd.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_hostapd.c
@@ -2201,7 +2201,7 @@ static int iw_softap_setwpsie(struct net_device *dev,
    hdd_hostapd_state_t *pHostapdState;
    eHalStatus halStatus= eHAL_STATUS_SUCCESS;
    u_int8_t *wps_genie;
-   u_int8_t *fwps_genie;
+   u_int8_t *fwps_genie = NULL;
    u_int8_t *pos;
    tpSap_WPSIE pSap_WPSIe;
    u_int8_t WPSIeType;


### PR DESCRIPTION

fix: drivers/staging/prima/CORE/HDD/src/wlan_hdd_hostapd.c:2219:13: warning: 'fwps_genie' may be used uninitialized in this function [-Wuninitialized]

Ref:
https://git.bricked.de/Bricked/flo/commit/72ba1d640a933df43f7960ec0caa4d20ce887c71

Edit: My bad, I put this in the wrong branch, supposed to be EX-7. However, may be same result.